### PR TITLE
Patch using method that accepts params to avoid upper-bound on parameter count

### DIFF
--- a/src/main/DebugLogger/MethodPatcher.cs
+++ b/src/main/DebugLogger/MethodPatcher.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 
-internal class MethodPatcher
+internal static class MethodPatcher
 {
     private static TextWriter GetWriter(object instance)
     {
@@ -22,64 +22,17 @@ internal class MethodPatcher
         return logger?.Configs.OutWriter ?? Console.Out;
     }
 
-    private static void PrintContext(object instance, 
-        MethodBase originalMethod, 
-        params object[] parameters)
+    private static void PrintContext(object __instance, 
+        MethodBase __originalMethod, 
+        params object[] __args)
     {
-        var writer = GetWriter(instance);
-        writer.WriteLine($"{originalMethod.DeclaringType.Name} - {originalMethod.Name}");
+        var writer = GetWriter(__instance);
+        writer.WriteLine($"{__originalMethod.DeclaringType.Name} - {__originalMethod.Name}");
 
-        var paramsInfo = originalMethod.GetParameters();
+        var paramsInfo = __originalMethod.GetParameters();
         for (int i = 0; i < paramsInfo.Length; i++)
         {
-            writer.WriteLine($"{paramsInfo[i].Name}: {parameters[i]}");
+            writer.WriteLine($"{paramsInfo[i].Name}: {__args[i]}");
         }
-    }
-
-    internal static void ContextLog_0(object __instance, MethodBase __originalMethod)
-    {
-        PrintContext(__instance, __originalMethod);
-    }
-
-    internal static void ContextLog_1(object __instance, MethodBase __originalMethod, 
-        object __0)
-    {
-        PrintContext(__instance, __originalMethod, __0);
-    }
-
-    internal static void ContextLog_2(object __instance, MethodBase __originalMethod,
-        object __0, object __1)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1);
-    }
-
-    internal static void ContextLog_3(object __instance, MethodBase __originalMethod, 
-        object __0, object __1, object __2)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1, __2);
-    }
-
-    internal static void ContextLog_4(object __instance, MethodBase __originalMethod,
-        object __0, object __1, object __2, object __3)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1, __2, __3);
-    }
-
-    internal static void ContextLog_5(object __instance, MethodBase __originalMethod, 
-        object __0, object __1, object __2, object __3, object __4)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1, __2, __3, __4);
-    }
-
-    internal static void ContextLog_6(object __instance, MethodBase __originalMethod, 
-        object __0, object __1, object __2, object __3, object __4, object __5)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1, __2, __3, __4, __5);
-    }
-
-    internal static void ContextLog_7(object __instance, MethodBase __originalMethod, 
-        object __0, object __1, object __2, object __3, object __4, object __5, object __6)
-    {
-        PrintContext(__instance, __originalMethod, __0, __1, __2, __3, __4, __5, __6);
     }
 }


### PR DESCRIPTION
By patching directly to the PrintContext method there was not need to create all the various patch methods with ever varying signatures. This way there is not limit on the number of parameters.